### PR TITLE
fixing kenlm from install_requires

### DIFF
--- a/exkaldi/config/nn_decode.py
+++ b/exkaldi/config/nn_decode.py
@@ -1,4 +1,4 @@
- config = {
+config = {
             "--beam-delta":[0.5,float],
             "--delta":[0.000976562,float],
             "--determinize-lattice":['true',str],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     data_files = [
             (os.path.join("exkaldisrc","tools"), glob.glob( os.path.join("tools","*")))
         ],
-    install_requires=["numpy>=1.16", "kenlm>=0.0"],
+    install_requires=["numpy>=1.16"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -23,16 +23,16 @@ def install_kenlm():
     kenlm_package="https://github.com/kpu/kenlm/archive/master.zip"
     subprocess.call([sys.executable, '-m', 'pip', 'install', '{0}'.format(kenlm_package)])
 
-try:
-    import kenlm
-except ImportError as error:
-    print("can't import kenlm")
-    print("Installing kenlm")
-    install_kenlm()
-except Exception as exception:
-    # Output unexpected Exceptions.
-    print(exception, False)
-    print(exception.__class__.__name__ + ": " + exception.message)
+#try:
+#    import kenlm
+#except ImportError as error:
+#    print("can't import kenlm")
+#    print("Installing kenlm")
+#    install_kenlm()
+#except Exception as exception:
+#    # Output unexpected Exceptions.
+#    print(exception, False)
+#    print(exception.__class__.__name__ + ": " + exception.message)
 
 setup(
     name="exkaldi",
@@ -47,7 +47,10 @@ setup(
     data_files = [
             (os.path.join("exkaldisrc","tools"), glob.glob( os.path.join("tools","*")))
         ],
-    install_requires=["numpy>=1.16"],
+    install_requires=[
+        "numpy>=1.16",
+        "kenlm @ https://github.com/kpu/kenlm/archive/master.zip#egg=pip",
+        ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
We show the WARNING if the kenlm is not installed, the Decoder's method will can't be use.